### PR TITLE
remove package mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = "Discord Python Starter Template"
 authors = ["Vineeth Voruganti <13438633+VVoruganti@users.noreply.github.com>"]
 license = "Apache 2.0"
 readme = "README.md"
-package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
When running `docker build -t discord-bot .`:
 
```
[+] Building 0.8s (11/14)                                          docker:desktop-linux
 => [internal] load build definition from Dockerfile                               0.0s
 => => transferring dockerfile: 1.07kB                                             0.0s
 => [internal] load metadata for docker.io/library/python:3.10-slim-bullseye       0.2s
 => [internal] load .dockerignore                                                  0.0s
 => => transferring context: 2B                                                    0.0s
 => [ 1/10] FROM docker.io/library/python:3.10-slim-bullseye@sha256:b94676419504f  0.0s
 => => resolve docker.io/library/python:3.10-slim-bullseye@sha256:b94676419504ff7  0.0s
 => [internal] load build context                                                  0.0s
 => => transferring context: 2.14kB                                                0.0s
 => CACHED [ 2/10] RUN apt-get update && apt-get install -y build-essential        0.0s
 => CACHED [ 3/10] WORKDIR /app                                                    0.0s
 => CACHED [ 4/10] RUN pip install "poetry==1.4.1"                                 0.0s
 => CACHED [ 5/10] WORKDIR /app                                                    0.0s
 => CACHED [ 6/10] COPY poetry.lock pyproject.toml /app/                           0.0s
 => ERROR [ 7/10] RUN poetry config virtualenvs.create false   && poetry install   0.6s
------
 > [ 7/10] RUN poetry config virtualenvs.create false   && poetry install --no-root --no-interaction --no-ansi --without dev:
0.555
0.555 The Poetry configuration is invalid:
0.555   - Additional properties are not allowed ('package-mode' was unexpected)
0.555
------
Dockerfile:25
--------------------
  24 |     # Project initialization:
  25 | >>> RUN poetry config virtualenvs.create false \
  26 | >>>   && poetry install --no-root --no-interaction --no-ansi --without dev
  27 |
--------------------
ERROR: failed to solve: process "/bin/sh -c poetry config virtualenvs.create false   && poetry install --no-root --no-interaction --no-ansi --without dev" did not complete successfully: exit code: 1
```

Removing this line fixes the issue, am I missing anything?