### PR TITLE
Add external prompt file support with BOT_PROMPT .env var

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@ fly.toml
 .env
 .env.template
 *.md
+!prompt.md
 docs/**
 .DS_Store
 supabase/**

--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,13 @@
 # Discord Bot Token used for authenticating your bot
 BOT_TOKEN=
 
+# Bot prompt: use "prompt.md" to load from file, or an inline prompt string
+#BOT_PROMPT=prompt.md
+BOT_PROMPT="You are a helpful dog who replies only in woofs"
+
+# Name of the bot in Discord, also used to identify the Docker container name
+BOT_NAME=
+
 # Name of your Application in Honcho
 APP_NAME=
 
@@ -14,4 +21,3 @@ HONCHO_URL=
 
 # The API key for the Honcho server
 HONCHO_API_KEY=
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Prompt file (if using an external prompt via .env BOT_PROMPT that you want to keep secret)
+prompt.md
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 # https://testdriven.io/blog/docker-best-practices/
 FROM python:3.11-slim-bullseye
 
+# Install git for dependencies that require it
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
 COPY --from=ghcr.io/astral-sh/uv:0.4.9 /uv /bin/uv
 
 # Set Working directory
@@ -34,6 +37,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV PATH="/app/.venv/bin:$PATH"
 
 COPY --chown=app:app src/ /app/src/
+COPY --chown=app:app prompt.md /app/
 
 # https://stackoverflow.com/questions/29663459/python-app-does-not-print-anything-when-running-detached-in-docker
 CMD ["python", "-u", "src/bot.py"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ variables used by the discord bot. Make a copy of this template and fill out the
 cp .env.template .env
 ```
 
+#### Bot Prompt
+
+The bot supports two ways of defeining custom prompts via the `BOT_PROMPT` environment variable:
+
+- **File-based**: Set `BOT_PROMPT=prompt.md` to load character definitions from `prompt.md`
+- **Inline**: Set `BOT_PROMPT="Your custom prompt text"` for simple prompts
+
 > [!CAUTION]
 > Make sure you do not push your `.env` file to GitHub or any other version
 > control. These should remain secret. By default the included `.gitignore` file
@@ -57,6 +64,12 @@ build the docker image and then run the bot using a local `.env` file.
 
 ```bash
 docker build -t discord-bot . && docker run --env-file .env discord-bot
+```
+
+For development, add `--rm` to automatically clean up the container when it stops:
+
+```bash
+docker build -t discord-bot . && docker run --rm --env-file .env discord-bot
 ```
 
 ## Deployment


### PR DESCRIPTION
- Add BOT_PROMPT env var supporting (1) prompt.md file in root (2) inline strings
- Add prompt preview logging and fallback handling
- Update docs and .env.example with prompt config info

WHY? Allows for longer prompts without bloating main app, and for prompt to be gitignored if required.

PS. Added `RUN apt-get update && apt-get install -y git` to Dockerfile as couldn't get honcho-ai dependency working otherwise (?)